### PR TITLE
fix: gpg-agent as ssh-agent using yubikey

### DIFF
--- a/zshenv
+++ b/zshenv
@@ -1,3 +1,2 @@
-
 export GPG_TTY=$(tty)
-. "$HOME/.cargo/env"
+gpg-connect-agent updatestartuptty /bye >/dev/null

--- a/zshrc
+++ b/zshrc
@@ -109,10 +109,6 @@ bindkey -v
 bindkey -a "k" history-beginning-search-backward
 bindkey -a "j" history-beginning-search-forward
 
-# Cannot be in zprofile, since current tty can be
-# different from the login shell's
-export GPG_TTY=$(tty)
-
 # autoload some functions
 for f ($(find $ZSH/functions/ -type f)); do
   source $f


### PR DESCRIPTION
from the gpg docs:
```
SSH has no way to tell the gpg-agent what terminal or X display it is
running on. So when remotely logging into a box where a gpg-agent with
SSH support is running, the pinentry will get popped up on whatever
display the gpg-agent has been started. To solve this problem you may
issue the command
```

https://www.gnupg.org/documentation/manuals/gnupg/Common-Problems.html