### PR TITLE
feat: add ssh config

### DIFF
--- a/dot.yml
+++ b/dot.yml
@@ -38,6 +38,8 @@ map:
     as: copy
     with:
       PinentryPrefix: '{{if eq .Os "darwin"}}/opt/homebrew/bin{{else}}/usr/bin{{end}}'
+  ssh/config:
+    as: copy
   dynamic-colors:
   bin/urxvt-perl:
     to: ~/.urxvt/ext

--- a/dots/ssh/config
+++ b/dots/ssh/config
@@ -1,0 +1,1 @@
+Match host * exec "gpg-connect-agent UPDATESTARTUPTTY /bye"

--- a/dots/zshrc
+++ b/dots/zshrc
@@ -129,4 +129,3 @@ if hash gdircolors &> /dev/null; then
 fi
 
 export GPG_TTY=$(tty)
-gpg-connect-agent updatestartuptty /bye >/dev/null


### PR DESCRIPTION
Instruct agent to `UPDATESTARTUPTTY` before an ssh session - this fixes issues around multiple terminals and/or split panes each setting the tty to its value; then, subsequent calls on previously started terminals/splits would fail.